### PR TITLE
Fix emoji detection

### DIFF
--- a/ac-web/src/hooks/useWS.ts
+++ b/ac-web/src/hooks/useWS.ts
@@ -74,7 +74,7 @@ export const useWS = () => {
                         // Handle user-generated events
                         if (eventData.event_code === 'user_event') {
                             // If the message already has an emoji at the start, use it
-                            const messageHasEmoji = /^\p{Emoji}/u.test(eventData.description);
+                            const messageHasEmoji = /^\p{Extended_Pictographic}/u.test(eventData.description);
                             emoji = messageHasEmoji ? "" : "🌐"; // Use globe emoji for user events if none present
                         }
                         


### PR DESCRIPTION
## Summary
- improve regex in the websocket hook to work on browsers that don't support `\p{Emoji}`

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `python3 -m py_compile backend/*.py`
